### PR TITLE
Refactor NuGet package publishing in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,4 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-
-name: publish
+name: Publish NuGet Package
 on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   push:
@@ -13,133 +11,12 @@ on:
     types:
       - published    # Run the workflow when a new GitHub release is published
 
-env:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_NOLOGO: true
-  NuGetDirectory: ${{ github.workspace}}/nuget
-
-defaults:
-  run:
-    shell: pwsh
-
 jobs:
-
-  # Create the NuGet package
-  create_nuget:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0 # Get all history to allow automatic versioning using MinVer
-
-
-    # Install .NET 9.0 SDK
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9.0.x' # Use a specific version or '9.0.x' for the latest 9.0 preview
-
-    # Build the NuGet package in the folder from the environment variable NuGetDirectory
-    - name: Build
-      run: dotnet build --configuration Release
-      
-    # Create the NuGet package in the folder from the environment variable NuGetDirectory
-    - name: Pack
-      run: dotnet pack --configuration Release --output ${{ env.NuGetDirectory }}
-
-    # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v4
-      with:
-        name: nuget
-        if-no-files-found: error
-        retention-days: 7
-        path: ${{ env.NuGetDirectory }}/*.nupkg
-  
-  # Run tests
-  run_test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    
-    # Install .NET 9.0 SDK
-    - name: Setup .NET 9.0
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: '9.0.x' # Use a specific version or '9.0.x' for the latest 9.0 preview
-    
-    - name: Run Tests
-      run: dotnet test --configuration Release
-
-  # Validate the NuGet package
-  validate_nuget:
-     runs-on: ubuntu-latest
-     needs: [ create_nuget, run_test ]
-     steps:
-    
-       # Install .NET 9.0 SDK
-       - name: Setup .NET 9.0
-         uses: actions/setup-dotnet@v4
-         with:
-           dotnet-version: '9.0.x' # Use a specific version or '9.0.x' for the latest 9.0 preview
-
-       # Download the NuGet package created in the previous job
-       - uses: actions/download-artifact@v4
-         with:
-           name: nuget
-           path: ${{ env.NuGetDirectory }}
-
-       - name: Install nuget validator
-         run: dotnet tool update Meziantou.Framework.NuGetPackageValidation.Tool --global
-
-       # Validate metadata and content of the NuGet package
-       # https://www.nuget.org/packages/Meziantou.Framework.NuGetPackageValidation.Tool#readme-body-tab
-       # If some rules are not applicable, you can disable them
-       # using the --excluded-rules or --excluded-rule-ids option
-       - name: Validate package
-         run: meziantou.validate-nuget-package (Get-ChildItem "${{ env.NuGetDirectory }}/*.nupkg")
-         continue-on-error: true # Continue on Error
-
-  # Inform Discord that new PR is available and needs approval for PROD
-  notify_discord:
-    if: github.event_name == 'Release'
-    runs-on: ubuntu-latest
-    needs: [ validate_nuget ]
-    steps:
-       - name: Notify Discord
-         uses: rjstone/discord-webhook-notify@v1.0.4
-         with:
-            severity: info
-            details: A new pull request is awaiting approval to initiate the creation of a NuGet package for FeatureMasterX.
-            webhookurl: ${{ secrets.DISCORD_WEBHOOK }}
-            
-
-  # Deploy to NuGet.org
-  deploy:
-    # Publish only when creating a GitHub Release
-    # https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
-    # You can update this logic if you want to manage releases differently
-    if: github.event_name == 'Release'
-    runs-on: ubuntu-latest
-    needs: [ validate_nuget ]
-    environment:
-      name: Production # Your environment name
-      url: ${{ steps.set-url.outputs.url }} # optional
-    steps:
-      # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v4
-        with:
-          name: nuget
-          path: ${{ env.NuGetDirectory }}
-
-      # Install the .NET SDK indicated in the global.json file
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v4
-
-      # Publish all NuGet packages to NuGet.org
-      # Use --skip-duplicate to prevent errors if a package with the same version already exists.
-      # If you retry a failed workflow, already published packages will be skipped without error.
-      - name: Publish NuGet package
-        run: |
-          foreach($file in (Get-ChildItem "${{ env.NuGetDirectory }}" -Recurse -Include *.nupkg)) {
-              dotnet nuget push $file --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json
-          }
+  publish:
+    uses: SkJonko/Centralized-Workflow-YAMLs/.github/workflows/nuget-publish-template.yaml@main
+    with:
+      project_name: 'FeatureMasterX'
+      need_run_test: true
+    secrets:
+      NUGET_APIKEY: ${{ secrets.NUGET_APIKEY }}
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
Updated the workflow to use a centralized template for publishing NuGet packages. Retained steps for creating, testing, and validating the package while simplifying the publishing process. Necessary secrets are now passed to the new reusable workflow.